### PR TITLE
LMS_XBLOCK_COMPLETION_PUBLISHED signal

### DIFF
--- a/lms/djangoapps/lms_xblock/mixin.py
+++ b/lms/djangoapps/lms_xblock/mixin.py
@@ -259,4 +259,7 @@ class LmsBlockMixin(XBlockMixin):
         if not completion_service.can_mark_block_complete_on_view(self):
             raise JsonHandlerError(400, "Block not configured for completion on view.")
         self.runtime.publish(self, "completion", data)
+        from lms.djangoapps.lms_xblock.signals import LMS_XBLOCK_COMPLETION_PUBLISHED
+        from completion.models import BlockCompletion
+        LMS_XBLOCK_COMPLETION_PUBLISHED.send(sender=BlockCompletion,completion=data.get("completion"),mixin=self)
         return {'result': 'ok'}

--- a/lms/djangoapps/lms_xblock/signals.py
+++ b/lms/djangoapps/lms_xblock/signals.py
@@ -1,0 +1,3 @@
+from django.dispatch import Signal
+
+LMS_XBLOCK_COMPLETION_PUBLISHED = Signal()


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:

- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
